### PR TITLE
GitLab.com support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 [![official project](http://jb.gg/badges/official.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub)
 
-Browser extension for Chrome and Firefox to check out GitHub projects and open them in JetBrains' IDEs in one click.
+Browser extension for Chrome and Firefox to check out GitHub and GitLab projects and open them in JetBrains' IDEs in one click.

--- a/gitlab.js
+++ b/gitlab.js
@@ -1,0 +1,79 @@
+/** @author Johannes Tegnér <johannes@jitesoft.com> */
+import 'whatwg-fetch';
+import 'core-js/library/modules/es7.object.values';
+
+import {
+  supportedLanguages,
+  supportedTools,
+  getToolboxURN,
+  USAGE_THRESHOLD
+} from './common';
+
+const node = document.querySelector('.project-repo-buttons');
+const regex = /https:\/\/gitlab.com\/(.+)/;
+
+function selectTools(languages) {
+  const overallPoints = Object.keys(languages).
+    map(lang => languages[lang]).
+    reduce((overall, current) => overall + current, 0);
+
+  const filterLang = lang =>
+    supportedLanguages[lang] &&
+    languages[lang] / overallPoints > USAGE_THRESHOLD;
+
+  const selectedToolIds = Object.keys(languages).
+    filter(filterLang).
+    reduce((selected, lang) => [...selected, ...supportedLanguages[lang]], []);
+
+  return selectedToolIds.length ? [...new Set(selectedToolIds)] : ['idea'];
+}
+
+function renderButtons(tools, meta) {
+  const group = document.createElement('div');
+  group.setAttribute('class', 'd-inline-flex');
+  group.setAttribute('style', 'margin-top: 16px;');
+  tools.map(id => supportedTools[id]).forEach(tool => {
+    const button = document.createElement('a');
+    button.setAttribute('href', getToolboxURN(tool.tag, meta.ssh));
+    button.setAttribute('class', 'input-group-text btn btn-xs');
+    button.setAttribute('aria-label', `Open in ${tool.name}`);
+    button.innerHTML = `<img src="${tool.icon}" width="16" height="16" style="vertical-align: text-top;">`;
+    group.appendChild(button);
+  });
+
+  node.appendChild(group);
+}
+
+function getMetaData() {
+  let element = null;
+  const children = document.querySelector('.project-metadata').children;
+
+  for (let i = children.length; i-- > 0;) {
+    // eslint-disable-next-line no-magic-numbers
+    if (children[i].innerHTML.indexOf('Project ID') !== -1) {
+      element = children[i];
+      break;
+    }
+  }
+
+  if (!element) {
+    return null;
+  }
+
+  const id = element.innerHTML.replace('Project ID:', '').trim();
+  // noinspection JSUnresolvedVariable
+  return fetch(`https://gitlab.com/api/v4/projects/${id}`).then(r => r.json()).then(meta => ({
+    ssh: meta.ssh_url_to_repo,
+    id: meta.id
+  }));
+}
+
+if (node && regex.test(window.location.href)) {
+  getMetaData().
+    then(meta => fetch(`https://gitlab.com/api/v4/projects/${meta.id}/languages`).
+      then(r => r.json()).
+      then(selectTools).
+      then(tools => renderButtons(tools, meta))).
+    catch(() => { /*Do nothing.*/ });
+}
+

--- a/manifest.json
+++ b/manifest.json
@@ -15,6 +15,15 @@
         "jetbrains-toolbox-common.js",
         "jetbrains-toolbox-github.js"
       ]
+    },
+    {
+      "matches": [
+        "*://*.gitlab.com/*"
+      ],
+      "js": [
+        "jetbrains-toolbox-common.js",
+        "jetbrains-toolbox-gitlab.js"
+      ]
     }
   ],
   "web_accessible_resources": [
@@ -22,6 +31,7 @@
   ],
   "permissions": [
     "activeTab",
-    "*://*.github.com/*"
+    "*://*.github.com/*",
+    "*://*.gitlab.com/*"
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "JetBrains Toolbox Extension",
-  "description": "This extension adds link to open project from GitHub in IntelliJ-based IDEs",
+  "description": "This extension adds link to open project from GitHub and GitLab in IntelliJ-based IDEs",
   "version": "1.0",
   "icons": {
     "128": "icon-128.png"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,7 @@ const LicenseChecker = require('@jetbrains/ring-ui-license-checker');
 module.exports = {
   entry: {
     github: './github',
+    gitlab: './gitlab',
     common: ['./common'] // https://github.com/webpack/webpack/issues/300
   },
   output: {


### PR DESCRIPTION
Added a gitlab.js file which enables support for GitLab.com in the plugin.  
I tried to keep the file as close to the `github.js` file in style as possible.

Updated the config file and manifest to include the new script on build.