### PR TITLE
Fix for GitLab metadata panel failure.

### DIFF
--- a/gitlab.js
+++ b/gitlab.js
@@ -45,7 +45,7 @@ function renderButtons(tools, meta) {
 
 function getMetaData() {
   let element = null;
-  const children = document.querySelector('.project-metadata').children;
+  const children = document.querySelector('.home-panel-metadata').children;
 
   for (let i = children.length; i-- > 0;) {
     // eslint-disable-next-line no-magic-numbers


### PR DESCRIPTION
The class of the Metadata panel changed from `.project-metadata` to `.home-panel-metadata`, making the plugin unable to fetch the ID of the project.

This Pull Request change the querySelector for the div in question.