### PR TITLE
Provide buttons for Bitbucket Cloud repositories

### DIFF
--- a/bitbucket.js
+++ b/bitbucket.js
@@ -1,0 +1,125 @@
+import 'whatwg-fetch';
+
+import {
+  getToolboxURN,
+  supportedLanguages,
+  supportedTools
+} from './common';
+
+const apiUrlMeta = document.querySelector("meta[name='bb-api-canon-url'][content]");
+const apiUrl = apiUrlMeta ? apiUrlMeta.getAttribute('content') : null;
+
+let styleSheetAdded = false;
+let addingButtons = false;
+
+function selectTools(language) {
+  // All languages in Bitbucket match the common list with an exception of HTML
+  if (language === 'html/css') {
+    language = 'html';
+  }
+
+  const selectedToolIds = language && supportedLanguages[language.toLowerCase()];
+  return selectedToolIds.length ? selectedToolIds : ['idea'];
+}
+
+function configureStyleSheet(fileName) {
+  if (!styleSheetAdded) {
+    const styleSheet = document.createElement("style");
+    // language=CSS
+    styleSheet.innerHTML = `
+      .jt-button {
+        margin: 0 2px;
+      }
+
+      .jt-button:hover {
+        background: rgba(9, 30, 66, 0.08);
+        cursor: pointer;
+      }
+
+      .jt-button img {
+        align-self: center;
+        width: 20px;
+        height: 20px;
+      }
+    `;
+
+    document.head.appendChild(styleSheet);
+    styleSheetAdded = true;
+  }
+}
+
+function renderButtons(tools, cloneCheckoutButton, cloneUrl) {
+  configureStyleSheet();
+
+  const buttonGroup = document.createElement('div');
+
+  tools
+    .map(toolId => supportedTools[toolId])
+    .forEach(tool => {
+      const btn = document.createElement('a');
+      btn.setAttribute('class', `${cloneCheckoutButton.className} jt-button`);
+      btn.setAttribute('href', getToolboxURN(tool.tag, cloneUrl));
+      btn.setAttribute('title', `Open in ${tool.name}`);
+      btn.innerHTML = `<img alt="${tool.name}" src="${tool.icon}">`;
+
+      buttonGroup.appendChild(btn);
+    });
+
+  const item = cloneCheckoutButton.parentNode;
+  item.parentNode.insertBefore(buttonGroup, item.nextSibling);
+}
+
+function getSshCloneUrl(links) {
+  for (const link of links.clone) {
+    if (link.name === 'ssh') {
+      return link.href;
+    }
+  }
+  return null;
+}
+
+function handleUiChange() {
+  if (addingButtons || document.getElementsByClassName('jt-button').length) {
+    // Buttons are being added or already exist in the DOM
+    return;
+  }
+
+  const fullSlug = window.location.pathname.match(/^\/([^/]+\/[^/]+)\/src\//);
+  const cloneCheckoutButton = document.querySelector('[data-qa="page-header-wrapper"] [class*="ActionsWrapper"] [type="button"]:not([aria-expanded])');
+
+  if (apiUrl && fullSlug && cloneCheckoutButton) {
+    addingButtons = true;
+    const metadataUrl = `${apiUrl}/2.0/repositories/${fullSlug[1]}?fields=language,links.clone`;
+
+    fetch(metadataUrl)
+      .then(response => response.json())
+      .then(rs => {
+        const tools = selectTools(rs.language);
+        const cloneUrl = getSshCloneUrl(rs.links);
+        renderButtons(tools, cloneCheckoutButton, cloneUrl);
+      })
+      .catch(() => { /*Do nothing.*/ })
+      .finally(() => addingButtons = false);
+  }
+}
+
+function run() {
+  const pageContent = document.querySelector('[class*="PageContent"]');
+
+  if (pageContent) {
+    // Set up mutation observer to deal with SPA navigation
+    new MutationObserver(function () {
+      handleUiChange();
+    }).observe(pageContent, {childList: true, subtree: true});
+  }
+
+  // Call it once no matter if we were able to set up mutation observer or not
+  handleUiChange();
+}
+
+// Wait for the UI to load completely
+document.addEventListener('readystatechange', function onReadyStateChange() {
+  if (document.readyState === "complete") {
+    run();
+  }
+}, false);

--- a/bitbucket.js
+++ b/bitbucket.js
@@ -6,9 +6,6 @@ import {
   supportedTools
 } from './common';
 
-const apiUrlMeta = document.querySelector("meta[name='bb-api-canon-url'][content]");
-const apiUrl = apiUrlMeta ? apiUrlMeta.getAttribute('content') : null;
-
 let styleSheetAdded = false;
 let addingButtons = false;
 
@@ -87,9 +84,9 @@ function handleUiChange() {
   const fullSlug = window.location.pathname.match(/^\/([^/]+\/[^/]+)\/src\//);
   const cloneCheckoutButton = document.querySelector('[data-qa="page-header-wrapper"] [class*="ActionsWrapper"] [type="button"]:not([aria-expanded])');
 
-  if (apiUrl && fullSlug && cloneCheckoutButton) {
+  if (fullSlug && cloneCheckoutButton) {
     addingButtons = true;
-    const metadataUrl = `${apiUrl}/2.0/repositories/${fullSlug[1]}?fields=language,links.clone`;
+    const metadataUrl = `${window.location.origin}/!api/2.0/repositories/${fullSlug[1]}?fields=language,links.clone`;
 
     fetch(metadataUrl)
       .then(response => response.json())

--- a/bitbucket.js
+++ b/bitbucket.js
@@ -1,3 +1,4 @@
+import {debounce} from 'throttle-debounce';
 import 'whatwg-fetch';
 
 import {
@@ -6,53 +7,61 @@ import {
   supportedTools
 } from './common';
 
-let styleSheetAdded = false;
-let addingButtons = false;
+const MUTATION_DEBOUNCE_DELAY = 300;
 
 function selectTools(language) {
   // All languages in Bitbucket match the common list with an exception of HTML
-  if (language === 'html/css') {
-    language = 'html';
-  }
+  const lang = language === 'html/css' ? 'html' : language;
 
-  const selectedToolIds = language && supportedLanguages[language.toLowerCase()];
-  return selectedToolIds.length ? selectedToolIds : ['idea'];
+  const selectedToolIds = lang && supportedLanguages[lang.toLowerCase()];
+  return selectedToolIds && selectedToolIds.length ? selectedToolIds : ['idea'];
 }
 
-function configureStyleSheet(fileName) {
-  if (!styleSheetAdded) {
-    const styleSheet = document.createElement("style");
-    // language=CSS
-    styleSheet.innerHTML = `
-      .jt-button {
-        margin: 0 2px;
-      }
-
-      .jt-button:hover {
-        background: rgba(9, 30, 66, 0.08);
-        cursor: pointer;
-      }
-
-      .jt-button img {
-        align-self: center;
-        width: 20px;
-        height: 20px;
-      }
-    `;
-
-    document.head.appendChild(styleSheet);
-    styleSheetAdded = true;
+function configureStyleSheet() {
+  const styleId = 'jt-bitbucket-style';
+  if (document.getElementById(styleId)) {
+    return;
   }
+
+  const styleSheet = document.createElement('style');
+  styleSheet.id = styleId;
+  // language=CSS
+  styleSheet.innerHTML = `
+    .jt-button {
+      margin: 0 2px;
+    }
+
+    .jt-button:hover {
+      background: rgba(9, 30, 66, 0.08);
+      cursor: pointer;
+    }
+
+    .jt-button img {
+      align-self: center;
+      width: 20px;
+      height: 20px;
+    }
+  `;
+
+  document.head.appendChild(styleSheet);
+}
+
+function buttonsShown() {
+  return !!document.getElementsByClassName('jt-button').length;
 }
 
 function renderButtons(tools, cloneCheckoutButton, cloneUrl) {
+  if (buttonsShown()) {
+    return;
+  }
+
   configureStyleSheet();
 
   const buttonGroup = document.createElement('div');
 
-  tools
-    .map(toolId => supportedTools[toolId])
-    .forEach(tool => {
+  tools.
+    map(toolId => supportedTools[toolId]).
+    forEach(tool => {
       const btn = document.createElement('a');
       btn.setAttribute('class', `${cloneCheckoutButton.className} jt-button`);
       btn.setAttribute('href', getToolboxURN(tool.tag, cloneUrl));
@@ -75,9 +84,8 @@ function getSshCloneUrl(links) {
   return null;
 }
 
-function handleUiChange() {
-  if (addingButtons || document.getElementsByClassName('jt-button').length) {
-    // Buttons are being added or already exist in the DOM
+const handleUiChange = debounce(MUTATION_DEBOUNCE_DELAY, () => {
+  if (buttonsShown()) {
     return;
   }
 
@@ -85,29 +93,26 @@ function handleUiChange() {
   const cloneCheckoutButton = document.querySelector('[data-qa="page-header-wrapper"] [class*="ActionsWrapper"] [type="button"]:not([aria-expanded])');
 
   if (fullSlug && cloneCheckoutButton) {
-    addingButtons = true;
     const metadataUrl = `${window.location.origin}/!api/2.0/repositories/${fullSlug[1]}?fields=language,links.clone`;
 
-    fetch(metadataUrl)
-      .then(response => response.json())
-      .then(rs => {
+    fetch(metadataUrl).
+      then(response => response.json()).
+      then(rs => {
         const tools = selectTools(rs.language);
         const cloneUrl = getSshCloneUrl(rs.links);
         renderButtons(tools, cloneCheckoutButton, cloneUrl);
-      })
-      .catch(() => { /*Do nothing.*/ })
-      .finally(() => addingButtons = false);
+      }).
+      catch(() => { /*Do nothing.*/ });
   }
-}
+});
 
 function run() {
   const pageContent = document.querySelector('[class*="PageContent"]');
 
   if (pageContent) {
     // Set up mutation observer to deal with SPA navigation
-    new MutationObserver(function () {
-      handleUiChange();
-    }).observe(pageContent, {childList: true, subtree: true});
+    new MutationObserver(handleUiChange).
+      observe(pageContent, {childList: true, subtree: true});
   }
 
   // Call it once no matter if we were able to set up mutation observer or not
@@ -116,7 +121,7 @@ function run() {
 
 // Wait for the UI to load completely
 document.addEventListener('readystatechange', function onReadyStateChange() {
-  if (document.readyState === "complete") {
+  if (document.readyState === 'complete') {
     run();
   }
 }, false);

--- a/common.js
+++ b/common.js
@@ -2,26 +2,26 @@
 /* globals chrome require */
 
 export const supportedLanguages = {
-  Java: ['idea'],
-  Kotlin: ['idea'],
-  Groovy: ['idea'],
-  Scala: ['idea'],
-  JavaScript: ['webstorm', 'phpstorm', 'idea'],
-  CoffeeScript: ['webstorm', 'phpstorm', 'idea'],
-  TypeScript: ['webstorm', 'phpstorm', 'idea'],
-  Dart: ['webstorm', 'phpstorm', 'idea'],
-  Go: ['goland'],
-  CSS: ['webstorm', 'phpstorm', 'idea'],
-  HTML: ['webstorm', 'phpstorm', 'idea'],
-  Python: ['pycharm', 'idea'],
-  PHP: ['phpstorm', 'idea'],
-  'C#': ['rider'],
-  'C++': ['clion'],
-  C: ['clion'],
-  Ruby: ['rubymine', 'idea'],
-  Puppet: ['rubymine', 'idea'],
-  'Objective-C': ['appcode'],
-  Swift: ['appcode']
+  java: ['idea'],
+  kotlin: ['idea'],
+  groovy: ['idea'],
+  scala: ['idea'],
+  javascript: ['webstorm', 'phpstorm', 'idea'],
+  coffeescript: ['webstorm', 'phpstorm', 'idea'],
+  typescript: ['webstorm', 'phpstorm', 'idea'],
+  dart: ['webstorm', 'phpstorm', 'idea'],
+  go: ['goland'],
+  css: ['webstorm', 'phpstorm', 'idea'],
+  html: ['webstorm', 'phpstorm', 'idea'],
+  python: ['pycharm', 'idea'],
+  php: ['phpstorm', 'idea'],
+  'c#': ['rider'],
+  'c++': ['clion'],
+  c: ['clion'],
+  ruby: ['rubymine', 'idea'],
+  puppet: ['rubymine', 'idea'],
+  'objective-c': ['appcode'],
+  swift: ['appcode']
 };
 
 export const supportedTools = {

--- a/github.js
+++ b/github.js
@@ -18,12 +18,12 @@ function selectTools(langs) {
     reduce((overall, current) => overall + current, 0);
 
   const filterLang = lang =>
-    supportedLanguages[lang] &&
+    supportedLanguages[lang.toLowerCase()] &&
     langs[lang] / overallPoints > USAGE_THRESHOLD;
 
   const selectedToolIds = Object.keys(langs).
     filter(filterLang).
-    reduce((selected, lang) => [...selected, ...supportedLanguages[lang]], []);
+    reduce((selected, lang) => [...selected, ...supportedLanguages[lang.toLowerCase()]], []);
 
   return selectedToolIds.length ? [...new Set(selectedToolIds)] : ['idea'];
 }

--- a/gitlab.js
+++ b/gitlab.js
@@ -17,12 +17,12 @@ function selectTools(languages) {
     reduce((overall, current) => overall + current, 0);
 
   const filterLang = lang =>
-    supportedLanguages[lang] &&
+    supportedLanguages[lang.toLowerCase()] &&
     languages[lang] / overallPoints > USAGE_THRESHOLD;
 
   const selectedToolIds = Object.keys(languages).
     filter(filterLang).
-    reduce((selected, lang) => [...selected, ...supportedLanguages[lang]], []);
+    reduce((selected, lang) => [...selected, ...supportedLanguages[lang.toLocaleLowerCase()]], []);
 
   return selectedToolIds.length ? [...new Set(selectedToolIds)] : ['idea'];
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "JetBrains Toolbox Extension",
-  "description": "This extension adds link to open project from GitHub and GitLab in IntelliJ-based IDEs",
+  "description": "This extension adds link to open project from GitHub, GitLab and Bitbucket in IntelliJ-based IDEs",
   "version": "1.0",
   "icons": {
     "128": "icon-128.png"
@@ -24,6 +24,16 @@
         "jetbrains-toolbox-common.js",
         "jetbrains-toolbox-gitlab.js"
       ]
+    },
+    {
+      "matches": [
+        "*://*.bitbucket.org/*"
+      ],
+      "js": [
+        "jetbrains-toolbox-common.js",
+        "jetbrains-toolbox-bitbucket.js"
+      ],
+      "run_at": "document_end"
     }
   ],
   "web_accessible_resources": [
@@ -33,6 +43,7 @@
     "activeTab",
     "nativeMessaging",
     "*://*.github.com/*",
-    "*://*.gitlab.com/*"
+    "*://*.gitlab.com/*",
+    "*://*.bitbucket.org/*"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "imports-loader": "0.6.5",
     "@jetbrains/logos": "0.1.6",
     "@jetbrains/ring-ui-license-checker": "^1.0.14",
+    "throttle-debounce": "2.1.0",
     "webpack": "1.12.11",
     "whatwg-fetch": "0.10.1"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,7 @@ module.exports = {
   entry: {
     github: './github',
     gitlab: './gitlab',
+    bitbucket: './bitbucket',
     common: ['./common'] // https://github.com/webpack/webpack/issues/300
   },
   output: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3206,6 +3206,11 @@ text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
 
+throttle-debounce@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-2.1.0.tgz#257e648f0a56bd9e54fe0f132c4ab8611df4e1d5"
+  integrity sha512-AOvyNahXQuU7NN+VVvOOX+uW6FPaWdAOdRP5HfwYxAfCzXTFKRMoIMk+n+po318+ktcChx+F1Dd91G3YHeMKyg==
+
 through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"


### PR DESCRIPTION
This change adds JetBrains Toolbox buttons for repositories hosted on [bitbucket.org](https://bitbucket.org).

Here's a screenshot (taken in [this repo](https://bitbucket.org/atlassian/atlaskit-mk-2)):

<img width="536" alt="JT Buttons for Bitbucket Cloud" src="https://user-images.githubusercontent.com/1497429/57086017-b72c9e80-6d40-11e9-9a96-397f5902b4db.png">