### PR TITLE
TBX-1441: Allow Toolbox browser extension to use HTTPS URL instead of SSH URL for cloning repositories

### DIFF
--- a/bitbucket.js
+++ b/bitbucket.js
@@ -23,12 +23,13 @@ if (!window.hasRun) {
       : supportedLanguages[DEFAULT_LANGUAGE];
   };
 
-  const renderButtons = (tools, cloneUrl) => {
+  const renderButtons = (tools, cloneUrl, sshUrl) => {
     const selectedTools = tools.
       sort().
       map(toolId => {
         const tool = supportedTools[toolId];
         tool.cloneUrl = getToolboxURN(tool.tag, cloneUrl);
+        tool.sshUrl = getToolboxURN(tool.tag, sshUrl);
         return tool;
       });
 
@@ -44,15 +45,22 @@ if (!window.hasRun) {
     });
   };
 
-  const getSshCloneUrl = links => links.clone.find(link => link.name === 'ssh') || null;
+  const getLink = (links, which) => {
+    const link = links.clone.find(l => l.name === which);
+    return link ? link.href : '';
+  };
+
+  const getCloneUrl = links => getLink(links, 'https');
+  const getSshCloneUrl = links => getLink(links, 'ssh');
 
   if (bitbucketMetadata) {
     fetch(`${bitbucketMetadata.api_url}?fields=language,links.clone`).
       then(response => response.json()).
       then(parsedResponse => {
         const tools = selectTools(parsedResponse.language);
-        const cloneUrl = getSshCloneUrl(parsedResponse.links);
-        renderButtons(tools, cloneUrl);
+        const cloneUrl = getCloneUrl(parsedResponse.links);
+        const sshUrl = getSshCloneUrl(parsedResponse.links);
+        renderButtons(tools, cloneUrl, sshUrl);
       }).
       catch(() => { /*Do nothing.*/ });
   }

--- a/common.js
+++ b/common.js
@@ -1,5 +1,3 @@
-/* eslint-disable import/no-commonjs,max-len */
-
 export const DEFAULT_LANGUAGE = 'java';
 
 export const supportedLanguages = {

--- a/common.js
+++ b/common.js
@@ -81,7 +81,3 @@ export const DEFAULT_LANGUAGE_SET = {[DEFAULT_LANGUAGE]: HUNDRED_PERCENT};
 export function getToolboxURN(tool, cloneUrl) {
   return `jetbrains://${tool}/checkout/git?checkout.repo=${cloneUrl}&idea.required.plugins.id=Git4Idea`;
 }
-
-(function enablePageActionIIFE() {
-  chrome.runtime.sendMessage({type: 'enable-page-action'});
-}());

--- a/enable-page-action.js
+++ b/enable-page-action.js
@@ -1,0 +1,1 @@
+chrome.runtime.sendMessage({type: 'enable-page-action'});

--- a/github.js
+++ b/github.js
@@ -118,12 +118,14 @@ if (!window.hasRun) {
   };
 
   const renderButtons = tools => {
-    const cloneUrl = `git@github.com:${githubMetadata.user}/${githubMetadata.repo}.git`;
+    const cloneUrl = `${githubMetadata.clone_url}.git`;
+    const sshUrl = `git@github.com:${githubMetadata.user}/${githubMetadata.repo}.git`;
     const selectedTools = tools.
       sort().
       map(toolId => {
         const tool = supportedTools[toolId];
         tool.cloneUrl = getToolboxURN(tool.tag, cloneUrl);
+        tool.sshUrl = getToolboxURN(tool.tag, sshUrl);
         return tool;
       });
 

--- a/gitlab.js
+++ b/gitlab.js
@@ -26,22 +26,22 @@ if (!window.hasRun) {
         break;
       }
     }
-    if (element === null) {
+    if (element) {
+      const id = element.textContent.replace('Project ID:', '').trim();
+      // noinspection JSUnresolvedVariable
+      fetch(`https://gitlab.com/api/v4/projects/${id}`).
+        then(r => r.json()).
+        then(meta => {
+          resolve({
+            ssh: meta.ssh_url_to_repo,
+            https: meta.http_url_to_repo,
+            id: meta.id
+          });
+        });
+    } else {
       reject();
     }
-
-    const id = element.textContent.replace('Project ID:', '').trim();
-    // noinspection JSUnresolvedVariable
-    fetch(`https://gitlab.com/api/v4/projects/${id}`).
-      then(r => r.json()).
-      then(meta => {
-        resolve({
-          ssh: meta.ssh_url_to_repo,
-          id: meta.id
-        });
-      });
   });
-
 
   const fetchLanguages = meta => new Promise(resolve => {
     fetch(`https://gitlab.com/api/v4/projects/${meta.id}/languages`).then(response => {
@@ -70,7 +70,8 @@ if (!window.hasRun) {
   const renderButtons = (tools, meta) => {
     const selectedTools = tools.sort().map(toolId => {
       const tool = supportedTools[toolId];
-      tool.cloneUrl = getToolboxURN(tool.tag, meta.ssh);
+      tool.cloneUrl = getToolboxURN(tool.tag, meta.https);
+      tool.sshUrl = getToolboxURN(tool.tag, meta.ssh);
       return tool;
     });
 

--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,10 @@
         "*://*.gitlab.com/*",
         "*://*.bitbucket.org/*"
       ],
-      "js": ["jetbrains-toolbox-common.js"]
+      "js": [
+        "jetbrains-toolbox-common.js",
+        "jetbrains-toolbox-enable-page-action.js"
+      ]
     },
     {
       "matches": ["*://*.github.com/*"],

--- a/popup/index.html
+++ b/popup/index.html
@@ -20,6 +20,12 @@
       padding: 0.1em;
     }
 
+    .tool-action-container {
+      align-items: center;
+      display: flex;
+      white-space: nowrap;
+    }
+
     .tool-action {
       align-items: center;
       display: flex;
@@ -29,6 +35,7 @@
 
     .tool-action__icon {
       box-sizing: border-box;
+      margin-right: 0.6em;
       width: 24px;
       height: 24px;
     }
@@ -36,7 +43,6 @@
     .tool-action__text {
       font-size: 1em;
       line-height: 1;
-      margin-left: 0.6em;
     }
 
     .tool-action_stub .tool-action__icon {

--- a/popup/index.html
+++ b/popup/index.html
@@ -20,12 +20,6 @@
       padding: 0.1em;
     }
 
-    .tool-action-container {
-      align-items: center;
-      display: flex;
-      white-space: nowrap;
-    }
-
     .tool-action {
       align-items: center;
       display: flex;
@@ -35,7 +29,7 @@
 
     .tool-action__icon {
       box-sizing: border-box;
-      margin-right: 0.6em;
+      margin-right: 0.5em;
       width: 24px;
       height: 24px;
     }
@@ -43,6 +37,10 @@
     .tool-action__text {
       font-size: 1em;
       line-height: 1;
+    }
+
+    .tool-action__link {
+      margin: 0 0.4em;
     }
 
     .tool-action_stub .tool-action__icon {
@@ -66,7 +64,7 @@
 <div id="tool-actions" class="tool-actions js-tool-actions">
   <div id="tool-action-stub" class="tool-action tool-action_stub">
     <div class="tool-action__icon"></div>
-    <div class="tool-action__text">Open in IDEA</div>
+    <div class="tool-action__text">Open in IDEA using HTTPS / SSH</div>
   </div>
 </div>
 <script src="jetbrains-toolbox-popup.js"></script>

--- a/popup/index.js
+++ b/popup/index.js
@@ -4,18 +4,44 @@ function createOpenToolAction(tool) {
   icon.setAttribute('alt', tool.name);
   icon.setAttribute('src', tool.icon);
 
-  const text = document.createElement('span');
-  text.setAttribute('class', 'tool-action__text');
-  text.textContent = `Open in ${tool.name}`;
+  const defaultText = document.createElement('span');
+  defaultText.setAttribute('class', 'tool-action__text');
+  defaultText.textContent = `Open in ${tool.name}`;
 
-  const action = document.createElement('a');
-  action.setAttribute('class', 'tool-action');
-  action.setAttribute('href', tool.cloneUrl);
-  action.setAttribute('aria-label', text.textContent);
+  const defaultAction = document.createElement('a');
+  defaultAction.setAttribute('class', 'tool-action');
+  defaultAction.setAttribute('href', tool.cloneUrl);
+  defaultAction.setAttribute('aria-label', defaultText.textContent);
 
-  action.appendChild(icon);
-  action.appendChild(text);
+  defaultAction.append(icon);
+  defaultAction.append(defaultText);
 
+  setClickHandler(defaultAction);
+
+  const sshText = document.createElement('span');
+  sshText.setAttribute('class', 'tool-action__text');
+  sshText.textContent = 'using SSH';
+
+  const sshAction = document.createElement('a');
+  sshAction.setAttribute('class', 'tool-action');
+  sshAction.setAttribute('href', tool.sshUrl);
+  sshAction.setAttribute('aria-label', sshText.textContent);
+
+  sshAction.append(sshText);
+
+  setClickHandler(sshAction);
+
+  const actionContainer = document.createElement('div');
+  actionContainer.setAttribute('class', 'tool-action-container');
+
+  actionContainer.append(defaultAction);
+  actionContainer.append('/');
+  actionContainer.append(sshAction);
+
+  return actionContainer;
+}
+
+function setClickHandler(action) {
   action.addEventListener('click', e => {
     e.preventDefault();
 
@@ -32,7 +58,6 @@ function createOpenToolAction(tool) {
         })();`
     });
   });
-  return action;
 }
 
 chrome.tabs.query({active: true, currentWindow: true}, tabs => {
@@ -43,9 +68,9 @@ chrome.tabs.query({active: true, currentWindow: true}, tabs => {
 
     const fragment = document.createDocumentFragment();
     tools.forEach(tool => {
-      fragment.appendChild(createOpenToolAction(tool));
+      fragment.append(createOpenToolAction(tool));
     });
     document.getElementById('tool-action-stub').style.display = 'none';
-    document.querySelector('.js-tool-actions').appendChild(fragment);
+    document.querySelector('.js-tool-actions').append(fragment);
   });
 });

--- a/popup/index.js
+++ b/popup/index.js
@@ -1,44 +1,39 @@
 function createOpenToolAction(tool) {
+  const toolAction = document.createElement('div');
+  toolAction.setAttribute('class', 'tool-action');
+
   const icon = document.createElement('img');
   icon.setAttribute('class', 'tool-action__icon');
   icon.setAttribute('alt', tool.name);
   icon.setAttribute('src', tool.icon);
 
-  const defaultText = document.createElement('span');
-  defaultText.setAttribute('class', 'tool-action__text');
-  defaultText.textContent = `Open in ${tool.name}`;
+  const actionText = document.createElement('span');
+  actionText.setAttribute('class', 'tool-action__text');
+  actionText.textContent = `Open in ${tool.name} using`;
 
-  const defaultAction = document.createElement('a');
-  defaultAction.setAttribute('class', 'tool-action');
-  defaultAction.setAttribute('href', tool.cloneUrl);
-  defaultAction.setAttribute('aria-label', defaultText.textContent);
+  const httpsLink = document.createElement('a');
+  httpsLink.setAttribute('class', 'tool-action__link');
+  httpsLink.setAttribute('href', tool.cloneUrl);
+  httpsLink.textContent = 'HTTPS';
+  setClickHandler(httpsLink);
 
-  defaultAction.append(icon);
-  defaultAction.append(defaultText);
+  const delimiter = document.createElement('span');
+  delimiter.setAttribute('class', 'tool-action__text');
+  delimiter.textContent = '/';
 
-  setClickHandler(defaultAction);
+  const sshLink = document.createElement('a');
+  sshLink.setAttribute('class', 'tool-action__link');
+  sshLink.setAttribute('href', tool.sshUrl);
+  sshLink.textContent = 'SSH';
+  setClickHandler(sshLink);
 
-  const sshText = document.createElement('span');
-  sshText.setAttribute('class', 'tool-action__text');
-  sshText.textContent = 'using SSH';
+  toolAction.append(icon);
+  toolAction.append(actionText);
+  toolAction.append(httpsLink);
+  toolAction.append(delimiter);
+  toolAction.append(sshLink);
 
-  const sshAction = document.createElement('a');
-  sshAction.setAttribute('class', 'tool-action');
-  sshAction.setAttribute('href', tool.sshUrl);
-  sshAction.setAttribute('aria-label', sshText.textContent);
-
-  sshAction.append(sshText);
-
-  setClickHandler(sshAction);
-
-  const actionContainer = document.createElement('div');
-  actionContainer.setAttribute('class', 'tool-action-container');
-
-  actionContainer.append(defaultAction);
-  actionContainer.append('/');
-  actionContainer.append(sshAction);
-
-  return actionContainer;
+  return toolAction;
 }
 
 function setClickHandler(action) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,6 +12,7 @@ module.exports = {
     gitlab: './gitlab',
     bitbucket: './bitbucket',
     common: ['./common'], // https://github.com/webpack/webpack/issues/300
+    'enable-page-action': './enable-page-action',
     background: './background',
     popup: './popup'
   },


### PR DESCRIPTION
Now popup actions look like "%icon% Open in %tool% / using SSH", where the first part (before /) opens via https and the second one (after /) via ssh