### PR TITLE
Switch to !api from api.bitbucket.org

### DIFF
--- a/bitbucket.js
+++ b/bitbucket.js
@@ -21,6 +21,9 @@ if (!window.hasRun) {
   const fetchMetadata = () => new Promise((resolve, reject) => {
     const metadata = bb(window.location.toString());
     if (metadata) {
+      // api.bitbucket.org intentionally doesn't support session authentication
+      // eslint-disable-next-line camelcase
+      metadata.api_url = metadata.api_url.replace('api.bitbucket.org/2.0', 'bitbucket.org/!api/2.0');
       fetch(`${metadata.api_url}?fields=links.clone`).
         then(response => response.json()).
         then(parsedResponse => {


### PR DESCRIPTION
`api.bitbucket.org` intentionally doesn't support browser session authentication which the extension uses to make requests. This makes it request `bitbucket.org/!api` instead, which is what
Bitbucket's UI is using.