### PR TITLE
Minor: Fix in exclusion regex (license check) to allow windows build.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -62,7 +62,7 @@ module.exports = {
       format: params => params.modules.map(mod => `${mod.name}@${mod.version} (${mod.url})
 ${mod.license.name} (${mod.license.url})`).join('\n\n'),
       filename: 'third-party-licences.txt',
-      exclude: /@jetbrains\/logos/
+      exclude: /@jetbrains[\/|\\]logos/
     })
   ]
 };


### PR DESCRIPTION
Due to path separators in windows, the exclusion of `@jetbrains/logos` in license check is broken.  
Linux-like systems uses `/`, while windows commonly uses `\`, new regex supports `/ OR \`, enabling windows users to build the source.