### PR TITLE
fix(buttonGroup): margin right instead of left

### DIFF
--- a/gitlab.js
+++ b/gitlab.js
@@ -220,7 +220,7 @@ const renderOpenActions = (tools, gitlabMetadata) => new Promise(resolve => {
   const buttonGroupAnchorElement = document.querySelector('.file-holder .file-actions .btn-group:last-child');
   if (buttonGroupAnchorElement) {
     const toolboxButtonGroup = document.createElement('div');
-    toolboxButtonGroup.setAttribute('class', 'btn-group ml-2');
+    toolboxButtonGroup.setAttribute('class', 'btn-group mr-2');
     toolboxButtonGroup.setAttribute('role', 'group');
 
     tools.forEach(tool => {


### PR DESCRIPTION
There is a little styling problem with the buttons where buttons are "attached" to the clone button.  
I fixed this by changing the margin from left to right.

Before:  
![image](https://user-images.githubusercontent.com/2607973/93028410-22180600-f614-11ea-8fad-2d555064b79c.png)

After:
![image](https://user-images.githubusercontent.com/2607973/93028447-5e4b6680-f614-11ea-8234-90796903b7e0.png)
