### PR TITLE
Avoid wrapping of Clone buttons on GitHub

### DIFF
--- a/github.js
+++ b/github.js
@@ -238,7 +238,7 @@ const renderCloneButtons = (tools, githubMetadata) => {
     let toolboxCloneButtonGroup = document.querySelector(`.${CLONE_BUTTON_GROUP_JS_CSS_CLASS}`);
     if (!toolboxCloneButtonGroup) {
       toolboxCloneButtonGroup = document.createElement('div');
-      toolboxCloneButtonGroup.setAttribute('class', `BtnGroup ml-2 ${CLONE_BUTTON_GROUP_JS_CSS_CLASS}`);
+      toolboxCloneButtonGroup.setAttribute('class', `BtnGroup ml-2 d-flex ${CLONE_BUTTON_GROUP_JS_CSS_CLASS}`);
 
       tools.forEach(tool => {
         const btn = createCloneButton(tool, githubMetadata);
@@ -256,7 +256,7 @@ const renderCloneButtons = (tools, githubMetadata) => {
       let toolboxCloneButtonGroup = document.querySelector(`.${CLONE_BUTTON_GROUP_JS_CSS_CLASS}`);
       if (!toolboxCloneButtonGroup) {
         toolboxCloneButtonGroup = document.createElement('div');
-        toolboxCloneButtonGroup.setAttribute('class', `BtnGroup mr-2 ${CLONE_BUTTON_GROUP_JS_CSS_CLASS}`);
+        toolboxCloneButtonGroup.setAttribute('class', `BtnGroup mr-2 d-flex ${CLONE_BUTTON_GROUP_JS_CSS_CLASS}`);
 
         tools.forEach(tool => {
           const btn = createCloneButton(tool, githubMetadata, false);


### PR DESCRIPTION
1. Visit https://github.com/JetBrains/toolbox-browser-extension
2. Resize the window to 1024px
3. Notice wrapped buttons

## Before

<img width="1023" alt="" src="https://user-images.githubusercontent.com/1402241/96544349-07b4f600-126c-11eb-8eff-c71d2043992c.png">

## After

<img width="1023" alt="" src="https://user-images.githubusercontent.com/1402241/96544503-4f3b8200-126c-11eb-9103-2c7feae18c8b.png">


Fixes https://github.com/sindresorhus/refined-github/issues/3671

No other extensions were enabled in the screenshot