### PR TITLE
Center the icons for 'open in IDE' buttons

### DIFF
--- a/github.js
+++ b/github.js
@@ -218,7 +218,7 @@ const createCloneButton = (tool, githubMetadata, small = true) => {
   buttonIcon.setAttribute('src', tool.icon);
   buttonIcon.setAttribute('width', '16');
   buttonIcon.setAttribute('height', '16');
-  buttonIcon.setAttribute('style', 'vertical-align:text-top');
+  buttonIcon.setAttribute('style', 'vertical-align:sub');
   button.appendChild(buttonIcon);
 
   addCloneButtonEventHandler(button, githubMetadata);

--- a/gitlab.js
+++ b/gitlab.js
@@ -168,7 +168,7 @@ const createCloneButton = (tool, gitlabMetadata) => {
   buttonIcon.setAttribute('src', tool.icon);
   buttonIcon.setAttribute('width', '16');
   buttonIcon.setAttribute('height', '16');
-  buttonIcon.setAttribute('style', 'vertical-align:text-top');
+  buttonIcon.setAttribute('style', 'vertical-align:sub');
   button.appendChild(buttonIcon);
 
   addCloneButtonEventHandler(button, gitlabMetadata);


### PR DESCRIPTION
Alignment of the open in IDE icons was slightly high, just changed the vertical alignment to center icons.
Please mark pull request with hacktoberfest-accepted ? :)