### PR TITLE
Compatibility with current "New Repository Overview" experiment on GitHub

### DIFF
--- a/github.js
+++ b/github.js
@@ -240,38 +240,36 @@ const renderCloneButtons = (tools, githubMetadata) => {
     });
 
     getRepoController.insertAdjacentElement('beforebegin', toolboxCloneButtonGroup);
+  } else {
+    // new UI as of 24.06.20
+    getRepoController = document.querySelector('get-repo');
 
-    return;
-  }
+    if (getRepoController) {
+      // https://github.com/orgs/community/discussions/61982
+      const isNewRepositoryOverview = getRepoController.
+        parentElement?.parentElement?.classList?.contains('pagehead-actions') ?? false;
 
-  // new UI as of 24.06.20
-  getRepoController = document.querySelector('get-repo');
+      const summary = getRepoController.querySelector('summary');
+      // the Code tab contains the green Code button (primary),
+      // the Pull requests tab contains the ordinary Code button (outlined)
+      const isOnCodeTab = summary && summary.classList.contains('Button--primary');
 
-  if (getRepoController) {
-    // https://github.com/orgs/community/discussions/61982
-    const isNewRepositoryOverview = getRepoController.
-      parentElement?.parentElement?.classList?.contains('pagehead-actions') ?? false;
+      const toolboxCloneButtonGroup = document.createElement(isNewRepositoryOverview ? 'li' : 'div');
+      const classes = isOnCodeTab
+        ? (!isNewRepositoryOverview && 'd-block ml-2')
+        : 'flex-md-order-2';
+      toolboxCloneButtonGroup.setAttribute(
+        'class',
+        `BtnGroup ${classes} ${CLONE_BUTTON_GROUP_JS_CSS_CLASS}`
+      );
 
-    const summary = getRepoController.querySelector('summary');
-    // the Code tab contains the green Code button (primary),
-    // the Pull requests tab contains the ordinary Code button (outlined)
-    const isOnCodeTab = summary && summary.classList.contains('Button--primary');
+      tools.forEach(tool => {
+        const btn = createCloneButton(tool, githubMetadata, !isOnCodeTab || isNewRepositoryOverview);
+        toolboxCloneButtonGroup.appendChild(btn);
+      });
 
-    const toolboxCloneButtonGroup = document.createElement(isNewRepositoryOverview ? 'li' : 'div');
-    const classes = isOnCodeTab
-      ? (!isNewRepositoryOverview && 'd-block ml-2')
-      : 'flex-md-order-2';
-    toolboxCloneButtonGroup.setAttribute(
-      'class',
-      `BtnGroup ${classes} ${CLONE_BUTTON_GROUP_JS_CSS_CLASS}`
-    );
-
-    tools.forEach(tool => {
-      const btn = createCloneButton(tool, githubMetadata, !isOnCodeTab || isNewRepositoryOverview);
-      toolboxCloneButtonGroup.appendChild(btn);
-    });
-
-    getRepoController.parentElement.insertAdjacentElement('beforebegin', toolboxCloneButtonGroup);
+      getRepoController.parentElement.insertAdjacentElement('beforebegin', toolboxCloneButtonGroup);
+    }
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "license": "Apache-2.0",
   "scripts": {
     "prebuild": "eslint .",
-    "prebuild2": "eslint . --fix",
     "build": "webpack --bail --mode production",
     "postbuild": "node .scripts/generate-readme.js | node .scripts/generate-license-list.js",
     "build:dev": "webpack --bail --mode development --devtool inline-source-map --infrastructure-logging-debug",


### PR DESCRIPTION
Hi 👋 

This implements support for the (currently) experimental "New Repository Overview" feature on GitHub.

Fixes: https://youtrack.jetbrains.com/issue/TBX-9862/JetBrains-Toolbox-Extension-doesnt-work-properly-on-new-github-naviagtion

Info: https://github.com/orgs/community/discussions/61982

<hr>

Current plugin:

With (old repository overview)

![image](https://github.com/JetBrains/toolbox-browser-extension/assets/30464310/e3af7872-c6c4-4697-a760-389c4ab173bc)

New Repository View (current plugin version):

![image](https://github.com/JetBrains/toolbox-browser-extension/assets/30464310/9b9b75de-23c8-4c70-af74-614c06edc8fa)

<hr>

Plugin disabled for reference:
![image](https://github.com/JetBrains/toolbox-browser-extension/assets/30464310/95b46917-237c-48ba-967e-5a1cb87c580d)

<hr>

With my changes applied:

![image](https://github.com/JetBrains/toolbox-browser-extension/assets/30464310/b5fbc0c1-c201-4928-85a7-ebf5e6eabe82)

With my changes applied & experiment disabled, as you can see current behaviour is still the same:

![image](https://github.com/JetBrains/toolbox-browser-extension/assets/30464310/76c059a6-4fda-4d9c-9ab5-81d50756ffe4)



